### PR TITLE
getting_started.md Updated for Python!

### DIFF
--- a/python/getting_started.md
+++ b/python/getting_started.md
@@ -11,9 +11,15 @@
 
 2. You are expected to write the code in `todo.py` file.
 
-3. Once you are done with the changes you should be able to execute the todo app by running the following commandfrom the terminal.
+3. Once you are done with the changes you should be able to execute the todo app by running the following command from the terminal.
 
-   **On Windows:**
+   **On Windows (Command Prompt):**
+
+   ```
+   todo.bat
+   ```
+
+   **On Windows (PowerShell):**
 
    ```
    ./todo.bat


### PR DESCRIPTION
Command "./todo" works differently for Command Prompt and Powershell on the Windows Operating System. So, I managed to change the getting_started.md in the Python folder. As it will show " '.' is not recognized as an internal or external command,
operable program or batch file." if not corrected in the README file and can create issues and confusion for the end-users.